### PR TITLE
Enforce default callback

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -125,6 +125,8 @@ export class SnackBar {
           this.stopTimer()
           if (callback) {
             callback(button, this)
+          } else {
+            this.destroy()
           }
         })
         el.appendChild(button)


### PR DESCRIPTION
Currently, if I want to edit an action buttons text and colour, I also have to specify a callback - if I don't, the message is never removed. If I'm satisfied with the default behaviour Snackbar provides (simply removing the message), it'd be quicker for me to not specify a callback and let Snackback use its `destroy()` function behind the scenes.