### PR TITLE
fix(pkg): add types field

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "module": "dist/snackbar.es.js",
   "types": "dist/index.d.ts",
   "files": [
+    "dist/index.d.ts",
     "dist/snackbar.es.js",
     "dist/snackbar.js",
     "dist/snackbar.min.js",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "description": "Show a brief message at the bottom of the screen.",
   "main": "dist/snackbar.js",
   "module": "dist/snackbar.es.js",
+  "types": "dist/index.d.ts",
   "files": [
-    "dist/index.d.ts",
     "dist/snackbar.es.js",
     "dist/snackbar.js",
     "dist/snackbar.min.js",


### PR DESCRIPTION
This module built with TypeScript, but type definition is not published as type definition.
Because I add `types` field to use type definition.

I am a beginner of npm, If you think you are not need this, please close this issue.

sincerely.
