### PR TITLE
feat: add Stack effect

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -190,6 +190,20 @@ export class Snackbar {
     this.wrapper.appendChild(el)
   }
 
+  stack() {
+    const l = instances.length
+    instances.forEach((instance, i) => {
+      if (instance.el) {
+        console.log(
+          `translate3d(0, -${(l - i) * 15}px, -${l - i}px), scale(${1 -
+            0.05 * (l - i)})`
+        )
+        instance.el.style.transform = `translate3d(0, -${(l - i) * 15}px, -${l -
+          i}px), scale(${1 - 0.05 * (l - i)})`
+      }
+    })
+  }
+
   /**
    * Destory the snackbar
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -330,22 +330,6 @@ export class Snackbar {
   }
 }
 
-function getTransitionEvent(el: HTMLDivElement): string | undefined {
-  const transitions: { [k: string]: string } = {
-    transition: 'transitionend',
-    OTransition: 'oTransitionEnd',
-    MozTransition: 'Transitionend',
-    WebkitTransition: 'webkitTransitionEnd'
-  }
-
-  for (const key of Object.keys(transitions)) {
-    if (el.style[key as any] !== undefined) {
-      return transitions[key]
-    }
-  }
-  return
-}
-
 function getAnimationEvent(el: HTMLDivElement): string | undefined {
   const animations: { [k: string]: string } = {
     animation: 'animationend',

--- a/src/index.ts
+++ b/src/index.ts
@@ -231,6 +231,10 @@ export class Snackbar {
   }
 
   expand() {
+    // Do not expand when hovering on hidden snackbar
+    if (this.el !== undefined && this.el.style.opacity === '0') {
+      return
+    }
     instanceStackStatus[this.options.position] = false
     const positionInstances = instances[this.options.position]
     const l = positionInstances.length - 1

--- a/src/index.ts
+++ b/src/index.ts
@@ -326,6 +326,8 @@ export function createSnackbar(message: string, options?: SnackOptions) {
 
 export function destroyAllSnackbars() {
   let instancesArray: Snackbar[] = []
-  Object.values(instances).forEach(map => instancesArray.push(...map.values()))
+  Object.keys(instances)
+    .map(position => instances[position])
+    .forEach(positionInstances => instancesArray.push(...positionInstances))
   return Promise.all(instancesArray.map(instance => instance.destroy()))
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,6 @@ export class Snackbar {
    */
   el?: HTMLDivElement
   private timeoutId?: number
-  private visibilityTimeoutId?: number
 
   constructor(message: string, options: SnackOptions = {}) {
     const {
@@ -213,7 +212,6 @@ export class Snackbar {
   }
 
   stack() {
-    this.toggleVisibility()
     instanceStackStatus[this.options.position] = true
     const positionInstances = instances[this.options.position]
     const l = positionInstances.length - 1
@@ -224,17 +222,13 @@ export class Snackbar {
       if (el) {
         el.style.transform = `translate3d(0, -${(l - i) * 15}px, -${l -
           i}px) scale(${1 - 0.05 * (l - i)})`
-        if (l - i >= this.options.maxStack) {
-          el.style.opacity = '0'
-        } else {
-          el.style.opacity = '1'
-        }
+        const hidden = l - i >= this.options.maxStack
+        this.toggleVisibility(el, hidden)
       }
     })
   }
 
   expand() {
-    this.toggleVisibility()
     instanceStackStatus[this.options.position] = false
     const positionInstances = instances[this.options.position]
     const l = positionInstances.length - 1
@@ -245,34 +239,22 @@ export class Snackbar {
       if (el) {
         el.style.transform = `translate3d(0, -${(l - i) *
           el.clientHeight}px, 0) scale(1)`
-        if (l - i >= this.options.maxStack) {
-          el.style.opacity = '0'
-        } else {
-          el.style.opacity = '1'
-        }
+        const hidden = l - i >= this.options.maxStack
+        this.toggleVisibility(el, hidden)
       }
     })
   }
 
-  toggleVisibility() {
-    const positionInstances = instances[this.options.position]
-    const l = positionInstances.length - 1
-    positionInstances.forEach((instance, i) => {
-      const { el } = instance
-      if (el) {
-        if (l - i >= this.options.maxStack) {
-          this.visibilityTimeoutId = self.setTimeout(() => {
-            el.style.visibility = 'hidden'
-          }, 300)
-        } else {
-          if (this.visibilityTimeoutId) {
-            clearTimeout(this.visibilityTimeoutId)
-            this.visibilityTimeoutId = undefined
-          }
-          el.style.visibility = 'visible'
-        }
-      }
-    })
+  toggleVisibility(el: HTMLDivElement, hidden: boolean) {
+    if (hidden) {
+      el.style.opacity = '0'
+      window.setTimeout(() => {
+        el.style.visibility = 'hidden'
+      }, 300)
+    } else {
+      el.style.opacity = '1'
+      el.style.visibility = 'visible'
+    }
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,6 +103,7 @@ export class Snackbar {
    */
   el?: HTMLDivElement
   private timeoutId?: number
+  private visibilityTimeoutId?: number
 
   constructor(message: string, options: SnackOptions = {}) {
     const {
@@ -247,11 +248,15 @@ export class Snackbar {
 
   toggleVisibility(el: HTMLDivElement, hidden: boolean) {
     if (hidden) {
-      el.style.opacity = '0'
-      window.setTimeout(() => {
+      this.visibilityTimeoutId = window.setTimeout(() => {
         el.style.visibility = 'hidden'
       }, 300)
+      el.style.opacity = '0'
     } else {
+      if (this.visibilityTimeoutId) {
+        clearTimeout(this.visibilityTimeoutId)
+        this.visibilityTimeoutId = undefined
+      }
       el.style.opacity = '1'
       el.style.visibility = 'visible'
     }

--- a/src/style.css
+++ b/src/style.css
@@ -11,20 +11,18 @@
 
 .snackbar {
   position: fixed;
-  display: flex;
   box-sizing: border-box;
   left: 50%;
-  bottom: 24px;
+  bottom: 14px;
   width: 344px;
   margin-left: -172px;
-  background: #2a2a2a;
-  border-radius: 2px;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.5);
   transform-origin: center;
-  color: #eee;
-  cursor: default;
   will-change: transform;
-  animation: snackbar-show 300ms ease forwards 1;
+  transition: transform 300ms ease, opacity 300ms ease;
+}
+
+.snackbar[aria-hidden='false'] {
+  animation: snackbar-show 300ms ease 1;
 }
 
 .snackbar[aria-hidden='true'] {
@@ -51,7 +49,7 @@
 @keyframes snackbar-show {
   from {
     opacity: 0;
-    transform: scale(0.5);
+    transform: translate3d(0, 100%, 0)
   }
 }
 
@@ -70,6 +68,16 @@
     margin-left: 0;
     border-radius: 0;
   }
+}
+
+.snackbar--container {
+  display: flex;
+  background: #2a2a2a;
+  border-radius: 2px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.5);
+  color: #eee;
+  cursor: default;
+  margin-bottom: 10px;
 }
 
 .snackbar--text {


### PR DESCRIPTION
Fix #16  

![Screen Recording 2019-07-24 at 11 59 PM](https://user-images.githubusercontent.com/11392695/61844939-514b4100-ae6f-11e9-81b6-d2dbeed23b62.gif)

Several major refactor/implementation details:
1. Instead of one `instances` array, now there's three arrays, each for one position. `instances` now is an object with three arrays properties, position being the key.
2. Adding a layer of container to hold `snackbar--text` and `snackbar--button`. This is needed for keeping the expanded status when hovering on snackbars. Previously, moving through expanded snackbars will go back to stack status because of the margin.
3. Rename the function and event to be animation related because hide is an animation. (This is a bug somewhat related to this change.)
4. Remove instance from array when destroyed. It should be from the beginning and it also effects the transition index if not cleared.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#16: Stack effect](https://issuehunt.io/repos/185049904/issues/16)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->