### PR TITLE
Fix type of SnackOptions theme property

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ export interface SnackOptions {
    * @default `center`
    */
   position?: Position
-  theme?: 'string' | ThemeRules
+  theme?: 'light' | 'dark' | ThemeRules
   /**
    * Maximum stacks to display, earlier created snackbar will be hidden
    * @default 3


### PR DESCRIPTION
The `theme` property can be set to "light" or "dark" (or a ThemeRules object).